### PR TITLE
feat(sec): add security response headers

### DIFF
--- a/traefik/dynamic.yml
+++ b/traefik/dynamic.yml
@@ -7,6 +7,18 @@ http:
         - websecure
       tls:
         certResolver: letsencrypt
+      middlewares:
+        - security
+
+  middlewares:
+    security:
+      headers:
+        forceSTSHeader: true
+        stsSeconds: 63072000
+        stsIncludeSubdomains: true
+        stsPreload: true
+        referrerPolicy: "strict-origin-when-cross-origin"
+        frameDeny: true
 
   services:
     app:


### PR DESCRIPTION
This PR adds Security response headers.

To test that security response headers are in effect, run the following curl command:
`curl -kI https://dhis2-127-0-0-1.nip.io/`

Response should should show the newly added headers + the DHIS2 headers as shown below:
<img width="594" height="195" alt="dhis-traefik-sec-headers" src="https://github.com/user-attachments/assets/de24b55e-2d80-4919-96ae-a223d7a83918" />


**_Note_**: Basic Auth (for the dashboard/api) isn't added for now. It will be added if we have a consensus.