### PR TITLE
fix: logging

### DIFF
--- a/init-scripts/01-create-postgis.sh
+++ b/init-scripts/01-create-postgis.sh
@@ -2,5 +2,4 @@
 set -e
 
 psql -v -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "CREATE EXTENSION IF NOT EXISTS postgis;"
-
 psql -v -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "SELECT PostGIS_Version();"

--- a/overlays/docker-compose.monitoring.yml
+++ b/overlays/docker-compose.monitoring.yml
@@ -84,9 +84,9 @@ services:
       - loki:/loki
     environment:
       LOKI_RETENTION_PERIOD: ${LOKI_RETENTION_PERIOD:-744h}
-    # Port is exposed as the Loki Docker Driver is running on the host network and we need to send logs to it from the service containers
+    # The Docker Logging Driver is running on the host network, and therefore we need to expose Loki on it
     ports:
-      - "127.0.0.1:3100:3100"
+      - "0.0.0.0:3100:3100"
     restart: unless-stopped
     healthcheck:
       test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--quiet", "--output-document=/dev/null", "http://localhost:3100/ready" ]

--- a/overlays/docker-compose.monitoring.yml
+++ b/overlays/docker-compose.monitoring.yml
@@ -9,6 +9,8 @@ x-loki-logging: &loki-logging
   options:
     # We're using the special DNS name host.docker.internal which resolves to the internal IP address used by the host, as the Loki Docker Driver is running on the host network and we need to send logs to it from the service containers
     loki-url: "http://host.docker.internal:3100/loki/api/v1/push"
+    loki-timeout: "1s"
+    loki-retries: "2"
 
 services:
   app:

--- a/overlays/docker-compose.monitoring.yml
+++ b/overlays/docker-compose.monitoring.yml
@@ -7,8 +7,7 @@ x-healthcheck-options: &healthcheck-options
 x-loki-logging: &loki-logging
   driver: loki
   options:
-    # We're using the special DNS name host.docker.internal which resolves to the internal IP address used by the host, as the Loki Docker Driver is running on the host network and we need to send logs to it from the service containers
-    loki-url: "http://host.docker.internal:3100/loki/api/v1/push"
+    loki-url: "http://localhost:3100/loki/api/v1/push"
     loki-timeout: "1s"
     loki-retries: "2"
 


### PR DESCRIPTION
### The goal of this PR is to implement a few bug fixes

Bind Loki to 0.0.0.0 (doesn't seem to work with 127.0.0.1)
Specify timeout and retries so containers doesn't hang if they can't reach Loki
Use localhost rather than host.docker.internal since the latter doesn't exist on Linux by default