### PR TITLE
fix: timezone format in BACKUP_TIMESTAMP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ reinit:
 check:
 	.venv/bin/pre-commit run --all-files
 
-BACKUP_TIMESTAMP := $(shell date +%Y-%m-%dT%H:%M:%S%z)
+BACKUP_TIMESTAMP := $(shell date +%Y-%m-%dT%H:%M:%S%Z)
 
 backup-database:
 	mkdir -p ./backups

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ reinit:
 check:
 	.venv/bin/pre-commit run --all-files
 
-BACKUP_TIMESTAMP := $(shell date +%Y-%m-%dT%H:%M:%S%Z)
+BACKUP_TIMESTAMP := $(shell date -u +%Y-%m-%d_%H-%M-%S_%Z)
 
 backup-database:
 	mkdir -p ./backups


### PR DESCRIPTION
The timestamp format `+%Y-%m-%dT%H:%M:%S%z` creates filenames like `2025-09-26T09:47:00+0200.pgc`, which might not be very portable.

This PR changes the format to `+%Y-%m-%d_%H-%M-%S_%Z` which will give something like `2025-09-26_09-47-00_CEST.pgc` instead.