### PR TITLE
chore: skip ownership and privileges when importing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -218,6 +218,7 @@ services:
     volumes:
       - ./backups:/backups:ro
       - ./scripts/restore-database.sh:/restore-database.sh:ro
+      - ./scripts/fix-ownership.sh:/fix-ownership.sh:ro
     environment:
       # -- Database hostname
       POSTGRES_HOST: database

--- a/scripts/fix-ownership.sh
+++ b/scripts/fix-ownership.sh
@@ -20,7 +20,6 @@ change_owner "SELECT tablename FROM pg_tables WHERE schemaname='public'" "TABLE"
 change_owner "SELECT sequence_name FROM information_schema.sequences WHERE sequence_schema='public'" "SEQUENCE"
 change_owner "SELECT table_name FROM information_schema.views WHERE table_schema='public'" "VIEW"
 
-# default privileges for future objects
 exec_psql "ALTER DEFAULT PRIVILEGES FOR ROLE $POSTGRES_USER IN SCHEMA public GRANT ALL ON TABLES TO $POSTGRES_USER"
 exec_psql "ALTER DEFAULT PRIVILEGES FOR ROLE $POSTGRES_USER IN SCHEMA public GRANT ALL ON SEQUENCES TO $POSTGRES_USER"
 exec_psql "ALTER DEFAULT PRIVILEGES FOR ROLE $POSTGRES_USER IN SCHEMA public GRANT ALL ON FUNCTIONS TO $POSTGRES_USER"

--- a/scripts/fix-ownership.sh
+++ b/scripts/fix-ownership.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+exec_psql() {
+  psql --host "$POSTGRES_HOST" --username postgres --dbname "$POSTGRES_DB" --tuples-only --no-align --quiet --command "$1"
+}
+
+change_owner() {
+  local query="$1"
+  local obj_type="$2"
+  entities=$(exec_psql "$query")
+  for entity in $entities; do
+      echo "Changing owner of $obj_type $entity to $POSTGRES_USER"
+      exec_psql "ALTER $obj_type \"$entity\" OWNER TO $POSTGRES_USER"
+  done
+}
+
+change_owner "SELECT tablename FROM pg_tables WHERE schemaname='public'" "TABLE"
+change_owner "SELECT sequence_name FROM information_schema.sequences WHERE sequence_schema='public'" "SEQUENCE"
+change_owner "SELECT table_name FROM information_schema.views WHERE table_schema='public'" "VIEW"
+
+# default privileges for future objects
+exec_psql "ALTER DEFAULT PRIVILEGES FOR ROLE $POSTGRES_USER IN SCHEMA public GRANT ALL ON TABLES TO $POSTGRES_USER"
+exec_psql "ALTER DEFAULT PRIVILEGES FOR ROLE $POSTGRES_USER IN SCHEMA public GRANT ALL ON SEQUENCES TO $POSTGRES_USER"
+exec_psql "ALTER DEFAULT PRIVILEGES FOR ROLE $POSTGRES_USER IN SCHEMA public GRANT ALL ON FUNCTIONS TO $POSTGRES_USER"

--- a/scripts/restore-database.sh
+++ b/scripts/restore-database.sh
@@ -19,7 +19,12 @@ until pg_isready --host "$POSTGRES_HOST" --username "$POSTGRES_USER"; do
   sleep 2
 done
 
-psql --host "$POSTGRES_HOST" --username postgres --dbname "$POSTGRES_DB" --command "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
+psql --host "$POSTGRES_HOST" --username postgres --dbname "$POSTGRES_DB" <<EOF
+DROP SCHEMA public CASCADE;
+CREATE SCHEMA public;
+GRANT USAGE ON SCHEMA public TO public;
+GRANT CREATE ON SCHEMA public TO public;
+EOF
 
 if echo "$DB_RESTORE_FILE" | grep --quiet "\\.sql\\.gz$"; then
   gunzip --stdout "/backups/$DB_RESTORE_FILE" \


### PR DESCRIPTION
The goal os this PR is to allow important of databases which were dumped using a different user than what's present in the database which is targeted for the restore.

PGC files are simply restored using the `--no-owner` and `--no-acl` flags of the `pg_restore` command. Plain SQL files are slightly more complicated since there are no such commands and we have to strip ownership and privileges from the SQL stream we're passing to `psql`.

Once the data has been restored under the posgres user ownership of the relevant entities are transferred to the actual owner.