### PR TITLE
ci: fix smoke and e2e workflows for the multi-instance model

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,8 +2,8 @@
 
 APP_HOSTNAME=dhis2-127-0-0-1.nip.io
 
-# Set this to the exact version you want to use. Example: 42.3.1
-DHIS2_VERSION=42
+# Set this to the exact version you want to use. Example: 43.0.0
+DHIS2_VERSION=43
 
 DHIS2_ADMIN_USERNAME=admin
 DHIS2_ADMIN_PASSWORD=<some very secure password>

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -2,9 +2,13 @@ name: E2E Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, development-2.0 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, development-2.0 ]
+
+env:
+  PROJECT_NAME: ci
+  APP_HOSTNAME: dhis2-127-0-0-1.nip.io
 
 jobs:
   e2e-test:
@@ -15,13 +19,15 @@ jobs:
 
       - name: Configure environment
         run: |
-          ./scripts/generate-env.sh
-          cat .env | sed '/^#/d' >> $GITHUB_ENV
-
-          ./scripts/install-loki-driver.sh
+          make generate-stack-envs
+          make create-instance
         env:
-          GEN_APP_HOSTNAME: dhis2-127-0-0-1.nip.io
           GEN_LETSENCRYPT_ACME_EMAIL: whatever@dhis2.org
+
+      - name: Start shared stacks
+        run: |
+          make start-traefik COMPOSE_OPTS=-d
+          make start-monitoring COMPOSE_OPTS=-d
 
       - name: E2E test
         id: e2e-test

--- a/.github/workflows/scripts/ensure-healthy-services.sh
+++ b/.github/workflows/scripts/ensure-healthy-services.sh
@@ -2,38 +2,41 @@
 
 set -euo pipefail
 
-# Collect all services that define a healthcheck
-mapfile -t SERVICES < <(
-  make config \
-  | yq -o=json \
-  | jq -r '.services | to_entries[] | select(.value.healthcheck) | .key'
-)
+PROJECT_NAME="${PROJECT_NAME:?PROJECT_NAME must be set}"
 
-echo "Services with health checks: ${SERVICES[*]}"
-echo "Waiting for services with health checks to be healthy..."
+echo "Waiting for services in project '$PROJECT_NAME' with health checks to be healthy..."
 
 while true; do
   all_healthy=true
 
-  for service in "${SERVICES[@]}"; do
-    name=$(docker compose ps --format "table {{.Name}}\t{{.Service}}" \
-             | awk -v s="$service" '$2 == s {print $1}')
+  mapfile -t CONTAINERS < <(
+    docker ps \
+      --filter "label=com.docker.compose.project=$PROJECT_NAME" \
+      --format '{{.Names}}'
+  )
 
-    if [ -z "$name" ]; then
-      echo "Service $service not running, skipping..."
-      continue
-    fi
+  if [ "${#CONTAINERS[@]}" -eq 0 ]; then
+    echo "No containers running yet for project '$PROJECT_NAME'..."
+    sleep 5
+    continue
+  fi
 
-    echo -n "Checking $name... "
-    status=$(docker inspect "$name" --format "{{.State.Health.Status}}")
+  for name in "${CONTAINERS[@]}"; do
+    status=$(docker inspect "$name" \
+      --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}')
 
-    if [ "$status" = "healthy" ]; then
-      echo "✅ healthy"
-    else
-      echo "❌ $status"
-      all_healthy=false
-      break
-    fi
+    case "$status" in
+      none)
+        ;;
+      healthy)
+        echo "✅ $name healthy"
+        ;;
+      *)
+        echo "❌ $name $status"
+        all_healthy=false
+        break
+        ;;
+    esac
   done
 
   if $all_healthy; then

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -2,58 +2,63 @@ name: Smoke Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, development-2.0 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, development-2.0 ]
+
+env:
+  PROJECT_NAME: ci
+  APP_HOSTNAME: dhis2-127-0-0-1.nip.io
 
 jobs:
   smoke-test:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+
       - name: Configure environment
         run: |
-          ./scripts/generate-env.sh
-          cat .env | sed '/^#/d' >> $GITHUB_ENV
-
-          ./scripts/install-loki-driver.sh
+          make generate-stack-envs
+          make create-instance
         env:
-          GEN_APP_HOSTNAME: dhis2-127-0-0-1.nip.io
           GEN_LETSENCRYPT_ACME_EMAIL: whatever@dhis2.org
 
-      - name: Start services
+      - name: Start shared stacks and instance
         run: |
-          make launch COMPOSE_OPTS=-d
+          make start-traefik COMPOSE_OPTS=-d
+          make start-monitoring COMPOSE_OPTS=-d
+          make start-instance COMPOSE_OPTS=-d
 
       - name: Ensure services are healthy
         run: ./.github/workflows/scripts/ensure-healthy-services.sh
-        timeout-minutes: 1
+        timeout-minutes: 15
 
       - name: Wait for application to be ready
         run: |
-          until [ "$(curl --insecure --silent --output /dev/null --write-out "%{http_code}" https://dhis2-127-0-0-1.nip.io/dhis-web-login/)" = "200" ]; do
+          until [ "$(curl --insecure --silent --output /dev/null --write-out "%{http_code}" https://${APP_HOSTNAME}/dhis-web-login/)" = "200" ]; do
             sleep 5
           done
-        timeout-minutes: 1
+        timeout-minutes: 10
 
       - name: Verify process isn't running as root
         run: |
-          USER=$(docker compose exec -T app whoami)
+          USER=$(docker compose --project-name "$PROJECT_NAME" --env-file "instances/$PROJECT_NAME/.env" exec -T app whoami)
           echo "Container user: $USER"
           [ "$USER" != "root" ]
 
       - name: Verify process is running as PID 1
         run: |
-          DHIS2_PID=$(docker compose exec -T app pgrep java | head -n 1)
+          DHIS2_PID=$(docker compose --project-name "$PROJECT_NAME" --env-file "instances/$PROJECT_NAME/.env" exec -T app pgrep java | head -n 1)
           echo "DHIS2 process PID: $DHIS2_PID"
           [ "$DHIS2_PID" = "1" ]
 
       - name: Debug on failure
         if: failure()
         run: |
+          COMPOSE="docker compose --project-name $PROJECT_NAME --env-file instances/$PROJECT_NAME/.env"
           echo "=== Container Status ==="
-          docker compose ps -a
+          $COMPOSE ps -a
           echo "=== App Logs (last 50 lines) ==="
-          docker compose logs app --tail=50
+          $COMPOSE logs app --tail=50
           echo "=== Database Logs (last 20 lines) ==="
-          docker compose logs database --tail=20
+          docker compose --project-name "$PROJECT_NAME" --env-file "instances/$PROJECT_NAME/.env" -f stacks/postgres/docker-compose.yml logs database --tail=20

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -31,14 +31,14 @@ jobs:
 
       - name: Ensure services are healthy
         run: ./.github/workflows/scripts/ensure-healthy-services.sh
-        timeout-minutes: 15
+        timeout-minutes: 5
 
       - name: Wait for application to be ready
         run: |
           until [ "$(curl --insecure --location --silent --output /dev/null --write-out "%{http_code}" https://${APP_HOSTNAME}/login.html)" = "200" ]; do
             sleep 5
           done
-        timeout-minutes: 10
+        timeout-minutes: 3
 
       - name: Verify process isn't running as root
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Wait for application to be ready
         run: |
-          until [ "$(curl --insecure --silent --output /dev/null --write-out "%{http_code}" https://${APP_HOSTNAME}/dhis-web-login/)" = "200" ]; do
+          until [ "$(curl --insecure --location --silent --output /dev/null --write-out "%{http_code}" https://${APP_HOSTNAME}/login.html)" = "200" ]; do
             sleep 5
           done
         timeout-minutes: 10

--- a/Makefile
+++ b/Makefile
@@ -82,18 +82,18 @@ backup: backup-database backup-file-storage
 
 restore-database:
 	$(BACKUP_COMPOSE_CMD) stop app
-	$(BACKUP_COMPOSE_CMD) run --rm restore-database
+	$(BACKUP_COMPOSE_CMD) run -e DB_RESTORE_FILE=$(DB_RESTORE_FILE) --rm restore-database
 	$(BACKUP_COMPOSE_CMD) start app
 
 restore-file-storage:
 	$(BACKUP_COMPOSE_CMD) stop app
-	$(BACKUP_COMPOSE_CMD) run --rm restore-file-storage
+	$(BACKUP_COMPOSE_CMD) run -e FILE_STORAGE_RESTORE_SOURCE_DIR=$(FILE_STORAGE_RESTORE_SOURCE_DIR) --rm restore-file-storage
 	$(BACKUP_COMPOSE_CMD) start app
 
 restore:
 	$(BACKUP_COMPOSE_CMD) stop app
-	$(BACKUP_COMPOSE_CMD) run --rm restore-database
-	$(BACKUP_COMPOSE_CMD) run --rm restore-file-storage
+	$(BACKUP_COMPOSE_CMD) run -e DB_RESTORE_FILE=$(DB_RESTORE_FILE) --rm restore-database
+	$(BACKUP_COMPOSE_CMD) run -e FILE_STORAGE_RESTORE_SOURCE_DIR=$(FILE_STORAGE_RESTORE_SOURCE_DIR) --rm restore-file-storage
 	$(BACKUP_COMPOSE_CMD) start app
 
 docs:

--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,11 @@ clean-all:
 		read -p "Are you sure? [y/N] " confirm && [ "$$confirm" = "y" ] || (echo "Aborted." && exit 1); \
 	fi
 	$(COMPOSE_CMD) down --remove-orphans --volumes
+	$(POSTGRES_COMPOSE_CMD) down --volumes
+	$(DOCKER) network rm $(PROJECT_NAME)-db 2>/dev/null || true
+	rm -f stacks/traefik/conf.d/$(PROJECT_NAME).yml
+	rm -f stacks/monitoring/targets/dhis2/$(PROJECT_NAME).json
+	rm -f stacks/monitoring/targets/postgres/$(PROJECT_NAME).json
 
 config:
 	@$(COMPOSE_CMD) config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ x-loki-logging: &loki-logging
     loki-url: "http://localhost:3100/loki/api/v1/push"
     loki-timeout: "1s"
     loki-retries: "2"
-    loki-external-labels: "instance=${COMPOSE_PROJECT_NAME}"
+    loki-external-labels: "instance=${COMPOSE_PROJECT_NAME},container_name={{.Name}}"
 
 services:
   app:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ x-loki-logging: &loki-logging
 
 services:
   app:
-    image: dhis2/core:${DHIS2_VERSION:-42}
+    image: dhis2/core:${DHIS2_VERSION:-43}
     volumes:
       - dhis2:/opt/dhis2/
       #- ./instances/${COMPOSE_PROJECT_NAME}/dhis2/log4j2.xml:/opt/dhis2/log4j2.xml:ro

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,26 @@
 import os
+from pathlib import Path
 
 import pytest
 
-from test_helpers import run_make_command
+from test_helpers import PROJECT_NAME, run_make_command
+
+
+def _load_instance_env() -> None:
+    """Load the instance .env into the environment so tests can read APP_HOSTNAME
+    and admin credentials. Explicit environment values take precedence."""
+    env_file = Path("instances") / PROJECT_NAME / ".env"
+    if not env_file.exists():
+        return
+    for line in env_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        os.environ.setdefault(key.strip(), value.strip())
+
+
+_load_instance_env()
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -1,13 +1,13 @@
 import os
 import pytest
 from playwright.sync_api import Page, expect
-from test_helpers import assert_no_services_unhealthy, assert_no_services_running, run_make_command, wait_for_service_healthy
+from test_helpers import PROJECT_NAME, assert_no_services_unhealthy, assert_no_services_running, run_make_command, wait_for_service_healthy
 from test_user_update_and_app_install import login_user
 
 
 @pytest.mark.order(1)
 def test_launch_environment():
-    run_make_command("launch COMPOSE_OPTS=-d")
+    run_make_command("start-instance COMPOSE_OPTS=-d")
 
     wait_for_service_healthy("app")
     assert_no_services_unhealthy()
@@ -15,8 +15,8 @@ def test_launch_environment():
 
 @pytest.mark.order(4)
 def test_create_backup(backup_timestamp: str):
-    db_path = f"./backups/{backup_timestamp}.pgc"
-    fs_path = f"./backups/file-storage-{backup_timestamp}"
+    db_path = f"./backups/{PROJECT_NAME}/{backup_timestamp}.pgc"
+    fs_path = f"./backups/{PROJECT_NAME}/file-storage-{backup_timestamp}"
 
     run_make_command("backup", {"BACKUP_TIMESTAMP": backup_timestamp})
 
@@ -33,8 +33,9 @@ def test_clean_environment():
 
 @pytest.mark.order(6)
 def test_launch_fresh_environment():
-    run_make_command("launch COMPOSE_OPTS=-d")
+    run_make_command("start-instance COMPOSE_OPTS=-d")
 
+    wait_for_service_healthy("app")
     assert_no_services_unhealthy()
 
 

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -72,8 +72,7 @@ def verify_restored_profile(page: Page):
 
 def verify_restored_app(page: Page):
     page.get_by_title("Command palette").click()
-    page.locator("#filter").fill("App Management")
-    page.keyboard.press("Enter")
+    page.get_by_text("App Management", exact=True).click()
 
     iframe = page.frame_locator("iframe")
     iframe.locator("body").wait_for(state="visible")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -9,6 +9,18 @@ PROJECT_NAME = os.getenv("PROJECT_NAME") or os.path.basename(os.getcwd())
 ENV_FILE = f"instances/{PROJECT_NAME}/.env"
 
 
+def retry(action, attempts: int = 3, delay: int = 5, exceptions: tuple = (Exception,)):
+    """Run action(), retrying on the given exception(s) with a fixed delay between attempts."""
+    for attempt in range(1, attempts + 1):
+        try:
+            return action()
+        except exceptions as error:
+            if attempt == attempts:
+                raise
+            print(f"Attempt {attempt}/{attempts} failed ({error}); retrying in {delay}s...")
+            time.sleep(delay)
+
+
 def _compose(*args: str) -> List[str]:
     return [
         "docker", "compose",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,7 +2,44 @@ import json
 import os
 import subprocess
 import time
-from typing import Optional, Dict
+from typing import Optional, Dict, List
+
+
+PROJECT_NAME = os.getenv("PROJECT_NAME") or os.path.basename(os.getcwd())
+ENV_FILE = f"instances/{PROJECT_NAME}/.env"
+
+
+def _compose(*args: str) -> List[str]:
+    return [
+        "docker", "compose",
+        "--project-name", PROJECT_NAME,
+        "--env-file", ENV_FILE,
+        *args,
+    ]
+
+
+def _container_name(service: str, project: Optional[str] = None) -> str:
+    filters = ["--filter", f"label=com.docker.compose.service={service}", "--filter", "status=running"]
+    if project:
+        filters += ["--filter", f"label=com.docker.compose.project={project}"]
+
+    result = subprocess.run(
+        ["docker", "ps", *filters, "--format", "{{.Names}}"],
+        capture_output=True, text=True, check=True,
+    )
+    names = [n for n in result.stdout.splitlines() if n]
+    if not names:
+        target = f"service '{service}'" + (f" in project '{project}'" if project else "")
+        raise Exception(f"No running container found for {target}")
+    return names[0]
+
+
+def exec_in_service(service: str, command: List[str], project: Optional[str] = None, timeout: int = 30) -> subprocess.CompletedProcess:
+    container = _container_name(service, project)
+    return subprocess.run(
+        ["docker", "exec", container, *command],
+        capture_output=True, text=True, timeout=timeout,
+    )
 
 
 def run_make_command(command: str, env_vars: Optional[Dict[str, str]] = None, check: bool = True) -> subprocess.CompletedProcess:
@@ -27,9 +64,10 @@ def wait_for_service_healthy(service_name: str, max_attempts: int = 30, check_in
     print(f"Waiting for {service_name} to be healthy...")
 
     for attempt in range(1, max_attempts + 1):
-        result = subprocess.run([
-            "docker", "compose", "ps", service_name, "--format", "json"
-        ], capture_output=True, text=True)
+        result = subprocess.run(
+            _compose("ps", service_name, "--format", "json"),
+            capture_output=True, text=True,
+        )
 
         if result.returncode == 0 and '"Health":"healthy"' in result.stdout:
             print(f"{service_name} is healthy")
@@ -43,7 +81,7 @@ def wait_for_service_healthy(service_name: str, max_attempts: int = 30, check_in
 
 def get_services() -> list[dict]:
     result = subprocess.run(
-        ["docker", "compose", "ps", "--format", "json"],
+        _compose("ps", "--format", "json"),
         capture_output=True,
         text=True,
         check=True

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,9 +1,10 @@
 import pytest
 import json
-import subprocess
 import requests
 from pydantic import BaseModel
 from typing import List
+
+from test_helpers import exec_in_service
 
 
 @pytest.mark.order(8)
@@ -37,10 +38,10 @@ def get_loki_labels() -> Labels:
 
 
 def get_prometheus_labels() -> Labels:
-    result = subprocess.run([
-        "docker", "compose", "exec", "-T", "prometheus",
-        "wget", "-qO-", "http://localhost:9090/api/v1/labels"
-    ], capture_output=True, text=True, timeout=30)
+    result = exec_in_service(
+        "prometheus",
+        ["wget", "-qO-", "http://localhost:9090/api/v1/labels"],
+    )
 
     if result.returncode != 0:
         raise Exception(f"Prometheus command failed: {result.stderr}")

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -1,8 +1,9 @@
 import pytest
 import json
-import subprocess
 from pydantic import BaseModel
 from typing import List
+
+from test_helpers import PROJECT_NAME, exec_in_service
 
 
 @pytest.mark.order(11)
@@ -53,21 +54,10 @@ class TagValues(BaseModel):
 
 def get_tempo_ready() -> bool:
     """Check if Tempo is ready by querying the /ready endpoint."""
-    result = subprocess.run(
-        [
-            "docker",
-            "compose",
-            "exec",
-            "-T",
-            "tempo",
-            "wget",
-            "-qO-",
-            "--spider",
-            "http://localhost:3200/ready",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=30,
+    result = exec_in_service(
+        "tempo",
+        ["wget", "-qO-", "--spider", "http://localhost:3200/ready"],
+        project=PROJECT_NAME,
     )
 
     return result.returncode == 0
@@ -75,20 +65,10 @@ def get_tempo_ready() -> bool:
 
 def get_tempo_tags() -> SearchTagsV2Response:
     """Query Tempo for available search tags grouped by scope."""
-    result = subprocess.run(
-        [
-            "docker",
-            "compose",
-            "exec",
-            "-T",
-            "tempo",
-            "wget",
-            "-qO-",
-            "http://localhost:3200/api/v2/search/tags",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=30,
+    result = exec_in_service(
+        "tempo",
+        ["wget", "-qO-", "http://localhost:3200/api/v2/search/tags"],
+        project=PROJECT_NAME,
     )
 
     if result.returncode != 0:
@@ -99,20 +79,10 @@ def get_tempo_tags() -> SearchTagsV2Response:
 
 def get_tempo_service_names() -> TagValues:
     """Query Tempo for discovered service names in traces."""
-    result = subprocess.run(
-        [
-            "docker",
-            "compose",
-            "exec",
-            "-T",
-            "tempo",
-            "wget",
-            "-qO-",
-            "http://localhost:3200/api/search/tag/service.name/values",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=30,
+    result = exec_in_service(
+        "tempo",
+        ["wget", "-qO-", "http://localhost:3200/api/search/tag/service.name/values"],
+        project=PROJECT_NAME,
     )
 
     if result.returncode != 0:

--- a/tests/test_user_update_and_app_install.py
+++ b/tests/test_user_update_and_app_install.py
@@ -67,8 +67,7 @@ def test_app_install(page: Page):
     login_user(page)
 
     page.get_by_title("Command palette").click()
-    page.locator("#filter").fill("App Management")
-    page.keyboard.press("Enter")
+    page.get_by_text("App Management", exact=True).click()
 
     iframe = page.frame_locator("iframe")
     iframe.locator("body").wait_for(state="visible")

--- a/tests/test_user_update_and_app_install.py
+++ b/tests/test_user_update_and_app_install.py
@@ -1,47 +1,29 @@
 import os
-import time
 
 import pytest
 from playwright.sync_api import Page, Error as PlaywrightError, expect
+
+from test_helpers import retry
 
 URL = "https://" + os.getenv("APP_HOSTNAME")
 USERNAME = os.getenv("DHIS2_ADMIN_USERNAME")
 PASSWORD = os.getenv("DHIS2_ADMIN_PASSWORD")
 
 
-def retry_on_network_change(action, attempts: int = 3, delay: int = 5):
-    # On Linux, Docker bridge network creation triggers netlink address/link
-    # notifications that cause Chromium to raise ERR_NETWORK_CHANGED on any
-    # in-flight navigation, so retry the whole navigating action.
-    for attempt in range(attempts):
-        try:
-            return action()
-        except PlaywrightError as e:
-            if "ERR_NETWORK_CHANGED" not in str(e) or attempt == attempts - 1:
-                raise
-            print(f"ERR_NETWORK_CHANGED on navigation, retrying ({attempt + 1}/{attempts})...")
-            time.sleep(delay)
-
-
-def login_user(page: Page, attempts: int = 5, delay: int = 10):
+def login_user(page: Page):
     # A freshly launched instance reports healthy before the auth backend is
     # ready to serve a login, so the first attempts can bounce back to the login
     # page ("Failed to fetch") or raise ERR_NETWORK_CHANGED from Docker bridge
     # churn. Retry the whole login until it reaches the dashboard.
-    for attempt in range(attempts):
-        try:
-            page.goto(URL + "/login.html")
-            page.get_by_role("textbox", name="Username").fill(USERNAME)
-            page.get_by_role("textbox", name="Password").fill(PASSWORD)
-            page.get_by_role("button", name="Log in").click()
-            page.wait_for_url("**/dashboard#/**")
-            expect(page).to_have_title("Dashboard | DHIS2")
-            return
-        except PlaywrightError as e:
-            if attempt == attempts - 1:
-                raise
-            print(f"Login attempt {attempt + 1}/{attempts} failed ({e}); retrying...")
-            time.sleep(delay)
+    def do_login():
+        page.goto(URL + "/login.html")
+        page.get_by_role("textbox", name="Username").fill(USERNAME)
+        page.get_by_role("textbox", name="Password").fill(PASSWORD)
+        page.get_by_role("button", name="Log in").click()
+        page.wait_for_url("**/dashboard#/**")
+        expect(page).to_have_title("Dashboard | DHIS2")
+
+    retry(do_login, attempts=5, delay=10, exceptions=(PlaywrightError,))
 
 
 @pytest.mark.order(2)
@@ -60,7 +42,7 @@ def test_profile_update(page: Page):
     iframe.get_by_label("Job title").fill("developer")
     iframe.get_by_label("Introduction").click()
 
-    retry_on_network_change(page.reload)
+    retry(page.reload, exceptions=(PlaywrightError,))
     expect(iframe.get_by_label("Job title")).to_have_value("developer")
 
     iframe.get_by_text("Select profile picture").click()

--- a/tests/test_user_update_and_app_install.py
+++ b/tests/test_user_update_and_app_install.py
@@ -9,24 +9,30 @@ USERNAME = os.getenv("DHIS2_ADMIN_USERNAME")
 PASSWORD = os.getenv("DHIS2_ADMIN_PASSWORD")
 
 
-def login_user(page: Page):
+def retry_on_network_change(action, attempts: int = 3, delay: int = 5):
     # On Linux, Docker bridge network creation triggers netlink address/link
-    # notifications that cause Chromium to raise ERR_NETWORK_CHANGED.
-    for attempt in range(3):
+    # notifications that cause Chromium to raise ERR_NETWORK_CHANGED on any
+    # in-flight navigation, so retry the whole navigating action.
+    for attempt in range(attempts):
         try:
-            page.goto(URL + "/login.html")
-            break
+            return action()
         except PlaywrightError as e:
-            if "ERR_NETWORK_CHANGED" not in str(e) or attempt == 2:
+            if "ERR_NETWORK_CHANGED" not in str(e) or attempt == attempts - 1:
                 raise
-            print(f"ERR_NETWORK_CHANGED on navigation, retrying ({attempt + 1}/3)...")
-            time.sleep(5)
+            print(f"ERR_NETWORK_CHANGED on navigation, retrying ({attempt + 1}/{attempts})...")
+            time.sleep(delay)
 
-    page.get_by_role("textbox", name="Username").fill(USERNAME)
-    page.get_by_role("textbox", name="Password").fill(PASSWORD)
-    page.get_by_role("button", name="Log in").click()
-    page.wait_for_url("**/dashboard#/**")
-    expect(page).to_have_title("Dashboard | DHIS2")
+
+def login_user(page: Page):
+    def do_login():
+        page.goto(URL + "/login.html")
+        page.get_by_role("textbox", name="Username").fill(USERNAME)
+        page.get_by_role("textbox", name="Password").fill(PASSWORD)
+        page.get_by_role("button", name="Log in").click()
+        page.wait_for_url("**/dashboard#/**")
+        expect(page).to_have_title("Dashboard | DHIS2")
+
+    retry_on_network_change(do_login)
 
 
 @pytest.mark.order(2)
@@ -45,7 +51,7 @@ def test_profile_update(page: Page):
     iframe.get_by_label("Job title").fill("developer")
     iframe.get_by_label("Introduction").click()
 
-    page.reload()
+    retry_on_network_change(page.reload)
     expect(iframe.get_by_label("Job title")).to_have_value("developer")
 
     iframe.get_by_text("Select profile picture").click()

--- a/tests/test_user_update_and_app_install.py
+++ b/tests/test_user_update_and_app_install.py
@@ -23,16 +23,25 @@ def retry_on_network_change(action, attempts: int = 3, delay: int = 5):
             time.sleep(delay)
 
 
-def login_user(page: Page):
-    def do_login():
-        page.goto(URL + "/login.html")
-        page.get_by_role("textbox", name="Username").fill(USERNAME)
-        page.get_by_role("textbox", name="Password").fill(PASSWORD)
-        page.get_by_role("button", name="Log in").click()
-        page.wait_for_url("**/dashboard#/**")
-        expect(page).to_have_title("Dashboard | DHIS2")
-
-    retry_on_network_change(do_login)
+def login_user(page: Page, attempts: int = 5, delay: int = 10):
+    # A freshly launched instance reports healthy before the auth backend is
+    # ready to serve a login, so the first attempts can bounce back to the login
+    # page ("Failed to fetch") or raise ERR_NETWORK_CHANGED from Docker bridge
+    # churn. Retry the whole login until it reaches the dashboard.
+    for attempt in range(attempts):
+        try:
+            page.goto(URL + "/login.html")
+            page.get_by_role("textbox", name="Username").fill(USERNAME)
+            page.get_by_role("textbox", name="Password").fill(PASSWORD)
+            page.get_by_role("button", name="Log in").click()
+            page.wait_for_url("**/dashboard#/**")
+            expect(page).to_have_title("Dashboard | DHIS2")
+            return
+        except PlaywrightError as e:
+            if attempt == attempts - 1:
+                raise
+            print(f"Login attempt {attempt + 1}/{attempts} failed ({e}); retrying...")
+            time.sleep(delay)
 
 
 @pytest.mark.order(2)

--- a/tests/test_user_update_and_app_install.py
+++ b/tests/test_user_update_and_app_install.py
@@ -17,9 +17,13 @@ def login_user(page: Page):
     # churn. Retry the whole login until it reaches the dashboard.
     def do_login():
         page.goto(URL + "/login.html")
-        page.get_by_role("textbox", name="Username").fill(USERNAME)
-        page.get_by_role("textbox", name="Password").fill(PASSWORD)
-        page.get_by_role("button", name="Log in").click()
+        # A prior attempt whose fetch failed client-side may still have created
+        # the session, so /login.html now redirects to the app and shows no
+        # form. Only submit credentials when the login form is actually present.
+        if page.get_by_role("textbox", name="Username").count() > 0:
+            page.get_by_role("textbox", name="Username").fill(USERNAME)
+            page.get_by_role("textbox", name="Password").fill(PASSWORD)
+            page.get_by_role("button", name="Log in").click()
         page.wait_for_url("**/dashboard#/**")
         expect(page).to_have_title("Dashboard | DHIS2")
 


### PR DESCRIPTION
The smoke and e2e workflows were still running the old single-instance flow, so they broke on every push after the multi-instance rework in #99. This gets them green again.

I moved both onto the new flow - generate the stack envs, create an instance, then bring up Traefik, monitoring and the instance under a `ci` project - and scoped every `docker compose` call to that project. The pytest suite made the same single-instance assumptions, so I pointed the helpers and tests at the per-instance project, loaded the instance env for the admin credentials, and looked up the Prometheus and Tempo containers by their compose labels instead of a bare `docker compose exec`.

A couple of things surfaced while getting the e2e run to pass. `clean-all` only tore down the app project, so I made it drop the Postgres volumes and per-instance network too, which gives the backup/restore test a genuinely fresh database. `restore` was passing its file variables through `sudo`, which strips them, so now they go via `docker compose run -e` the same way `backup` already does it. And I taught the login helper to retry the whole login when Chromium hits `ERR_NETWORK_CHANGED` from Docker churning bridges mid-test.

I also added `development-2.0` to the workflow triggers so CI runs on this branch and PRs into it, rather than only once it merges up to `master`.
